### PR TITLE
Add makeMapConverter function

### DIFF
--- a/json-mapper.js
+++ b/json-mapper.js
@@ -99,6 +99,22 @@ var makeConverter = module.exports.makeConverter = function(schema){
 };
 
 /**
+ * generate a converter to map a converter to an array
+ * @param  convert
+ * @return {Function}
+ */
+module.exports.makeMapConverter = function(convert){
+
+    return function(input){
+        var result = [];
+        input.forEach(function(obj){
+            result.push(convert(obj));
+        });
+        return result;
+    };
+};
+
+/**
  * make getVal factory
  * @param pth
  * @returns {Function}

--- a/test/main.js
+++ b/test/main.js
@@ -6,6 +6,7 @@ global.expect = require('chai').expect;
 
 require('./path');
 require('./makeConverter');
+require('./makeMapConverter');
 require('./chain');
 require('./map');
 require('./helpers');

--- a/test/makeMapConverter.js
+++ b/test/makeMapConverter.js
@@ -1,0 +1,31 @@
+var JM = require('../');
+
+describe('makeMapConverter', function(){
+
+    it('should map a converter on an array',function(){
+
+        var input = [
+            {
+                a: '1',
+                b: '2'
+            },
+            {
+                a: '3',
+                b: '4'
+            }
+        ];
+
+        var objConverter = JM.makeConverter({
+            a: 'a'
+        });
+
+        var arrConverter = JM.makeMapConverter(objConverter);
+
+        var output = arrConverter(input);
+
+        output.should.be.an.Array;
+        output.should.be.of.length(2);
+        output.should.contain({ a: '1'});
+        output.should.contain({ a: '3'});
+    });
+})


### PR DESCRIPTION
Fixes #7.  Creates a converter which maps another converter on an array:

``` js
var input = [
    {
        a: '1',
        b: '2'
    },
    {
        a: '3',
        b: '4'
    }
];

var objConverter = jm.makeConverter({
    a: 'a'
});

var arrayConverter = jm.makeMapConverter(objConverter);

arrayConverter(input);

/*
Result:

[
    {
        a: '1'
    },
    {
        a: '3'
    }
]
*/
```
