### PR TITLE
Add toString helper and fix unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ Result:
 
 ```
 
-toBoolean, toNumber, toUndefined, filterUndefined
+toBoolean, toNumber, toString, toUndefined, filterUndefined
 ----------------------------------------------
 
 ```js
@@ -537,6 +537,7 @@ var h = JM.helpers;
 var converter = JM.makeConverter({
     isGuest: ['role', h.toBoolean],
     isUser: ['user', h.toBoolean],
+    role: ['role', h.toString],
     userId: ['userId', h.toNumber],
     catalogId: ['catalogId', h.toNumber],
     catalogId2: ['catalogId', h.toNumber, h.toUndefined],
@@ -565,6 +566,7 @@ Result is:
 
 {
     isGuest: true,
+    role: '2',
     userId: 13,
     catalogId: NaN,
     catalogId3: 'somethingLiteral1'

--- a/json-mapper.js
+++ b/json-mapper.js
@@ -233,6 +233,13 @@ module.exports.helpers = {
     filterUndefined:filterUndefined,
     toBoolean:filterUndefined(Boolean),
     toNumber:filterUndefined(Number),
+    toString:function(input){
+        if (input === null || typeof input === 'undefined'){
+            return '';
+        }
+
+	return String(input)
+    },
     toUndefined:function(input){
         if (isNaN(input) || input === null || typeof input === 'undefined'){
             return void 0;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -165,6 +165,27 @@ describe('helpers', function(){
             should.equal(H.toBoolean(undefined),void 0);
       });  
     });
+
+    describe('helpers.toString', function(){
+      it('should be \'1000\'',function(){
+            should.equal(H.toString(1000),'1000');
+      });
+      it('should be \'true\'',function(){
+            should.equal(H.toString(true),'true');
+      });
+      it('should be \'false\'',function(){
+            should.equal(H.toString(false),'false');
+      });
+      it('should still be a string',function(){
+            should.equal(H.toString('test'),'test');
+      });
+      it('should be empty if null',function(){
+            should.equal(H.toString(null),'');
+      });
+      it('should be empty if undefined',function(){
+            should.equal(H.toString(undefined),'');
+      });
+    });
     
     
 });

--- a/test/makeMapConverter.js
+++ b/test/makeMapConverter.js
@@ -23,9 +23,9 @@ describe('makeMapConverter', function(){
 
         var output = arrConverter(input);
 
-        output.should.be.an.Array;
+        output.should.be.an('array');
         output.should.be.of.length(2);
-        output.should.contain({ a: '1'});
-        output.should.contain({ a: '3'});
+        output.should.deep.contains({ a: '2'});
+        output.should.deep.contains({ a: '3'});
     });
 })


### PR DESCRIPTION
I added a `toString` helper, the difference of using it instead of just
`String` is that it handles null and undefined vars.

I also fix unit tests with new Chai `should` assertions.