### PR TITLE
Fix files of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "url": "git://github.com/dregenor/jsonMapper.git"
   },
   "files": [
-    "index.js",
-    "json-mapper"
+    "json-mapper.js"
   ],
   "keywords": [
     "json",


### PR DESCRIPTION
The version `0.0.11` from NPM is without `json-mapper.js`. In `files` key of `package.json` we need to specify file extension to be included when we publish the package to NPM.

Additionally, we don't need to specify `index.js` in `files` key because it is the `main` script of the package.